### PR TITLE
Updated Pillow

### DIFF
--- a/PyNuclei/static/.config
+++ b/PyNuclei/static/.config
@@ -1,1 +1,1 @@
-{"FIRST_RUN": true}
+{"FIRST_RUN": false}

--- a/requirments.txt
+++ b/requirments.txt
@@ -1,4 +1,4 @@
 PyYAML
 requests
 fake_useragent
-Pillow<=9.5.0
+Pillow<=10.4.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="PyNuclei",
-    version="1.4.3",
+    version="1.4.4",
     author="Vaibhav Kushwaha",
     author_email="vaibhavkush.007@gmail.com",
     description="PyNuclei is an unofficial python library for Nuclei Scanner.",
@@ -21,5 +21,5 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['static', 'static.*']),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["PyYAML", "requests", "fake_useragent", "Pillow<=9.5.0"],
+    install_requires=["PyYAML", "requests", "fake_useragent", "Pillow<=10.4.0"],
 )


### PR DESCRIPTION
Tried to install PyNuclei on a OSX and Kali environment.
On both situations I received an error when trying to do that.

```
└─$ pip install pynuclei                             
Collecting pynuclei
  Using cached pynuclei-1.4.3-py3-none-any.whl.metadata (4.8 kB)
Collecting PyYAML (from pynuclei)
  Using cached PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
Requirement already satisfied: requests in ./pyenv/lib/python3.13/site-packages (from pynuclei) (2.32.3)
Collecting fake_useragent (from pynuclei)
  Using cached fake_useragent-2.1.0-py3-none-any.whl.metadata (17 kB)
Collecting Pillow<=9.5.0 (from pynuclei)
  Using cached Pillow-9.5.0.tar.gz (50.5 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [24 lines of output]
      Traceback (most recent call last):
        File "/home/eantonini/github/security-repos/externus-project/pyenv/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
          ~~~~^^
        File "/home/eantonini/github/security-repos/externus-project/pyenv/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/eantonini/github/security-repos/externus-project/pyenv/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-2rkq5y7p/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 334, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-2rkq5y7p/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 304, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/tmp/pip-build-env-2rkq5y7p/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 522, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-2rkq5y7p/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 320, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 29, in <module>
        File "<string>", line 26, in get_version
      KeyError: '__version__'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
``` 

So I updated Pillow requirement and It worked.