### PR TITLE
This is a quick fix for installing with python >= 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML
 requests
 fake_useragent
 Pillow<=10.4.0
+setuptools


### PR DESCRIPTION
Relating to : https://github.com/kushvaibhav/PyNuclei/issues/11

- Added setuptools in the requirements as it comes with its own distutils package.
- Fixed the typo on the requirements.txt file (which made auto install with -r and custom scripts a pain on my side)